### PR TITLE
Adds initial version of front end style guide

### DIFF
--- a/05_frontend.md
+++ b/05_frontend.md
@@ -21,7 +21,7 @@ First and foremost if something ever looks bad, please say something.
 
 ## Links
 
-* Primary link color is cyan blue #00a6ce with a hover of #007da4
+* Primary link color is cyan blue #<span class="primary-blue">00a6ce</span> with a hover of #<span class="hover-blue">007da4</span>
 
 ## Forms
 
@@ -45,8 +45,6 @@ if there are form errors, it is not clear what the label is
   * If there is a mix of required and optional fields, put an nbsp; and asterisk after the label 
   for the required field in the same color as the label
 
-
-
 ## Buttons
 
 * .125em rounded corners
@@ -57,17 +55,17 @@ if there are form errors, it is not clear what the label is
 
 ### Button Colors
 
-* Primary - orange (ff4c00)
+* Primary - orange (<span class="primary-orange">ff4c00</span>)
   * Main action buttons like "save"; most POST actions
-* Primary - cyan blue (00a6ce)
+* Primary - cyan blue (<span class="primary-blue">00a6ce</span>)
   * Most GET actions; or POST actions with only light edits and/or if there is already an orange 
   button and we need to differentiate
-* Secondary - gray (999)
+* Secondary - gray (<span class="secondary-gray">999</span>)
   * GET actions if there is already a cyan button
-* Other - red (f6323e)
+* Other - red (<span class="other-red">f6323e</span>)
   * Not a standard Kotis color, but ok to use if we need a "delete" or "cancel" or just general 
   warning button
-* Other - green (00b44f)
+* Other - green (<span class="other-green">00b44f</span>)
   * Try not to use this unless we need to, not a standard Kotis color
 * Try to use the above color concepts very closely for internal uses. On an external page if the 
 buttons look bad or conflict with other graphics, please say something
@@ -108,12 +106,12 @@ example)
 
 ## Flash Messages
 
-* Success messages should have a full-width green background (00b44f)
+* Success messages should have a full-width green background (<span class="other-green">00b44f</span>)
   * black text
   * no border
   * .5em padding
   * .125em rounded corners
-* Failure/warning messages should be the same except red background (f6323e)
+* Failure/warning messages should be the same except red background (<span class="other-red">f6323e</span>)
 
 ## Headers
 

--- a/05_frontend.md
+++ b/05_frontend.md
@@ -1,0 +1,125 @@
+---
+layout: page
+title: Front End
+permalink: /frontend/
+---
+
+# Front End
+
+This is an initial version of a front end style guide. This is going to be somewhat fluid at the
+start and we will most likely need to add, remove and change aspects of this as we progress.
+First and foremost if something ever looks bad, please say something.
+
+## Font Face
+
+* `font-family:'Open Sans',sans-serif`
+
+## Font Size
+
+* Use standard Pure font sizes, which start at 1em and uses these sizes for headers:
+`<h1>2em</h1>`, `<h2>1.5em</h2>`, `<h3>1.17em</h3>`, `<h4>1em</h4>`
+
+## Links
+
+* Primary link color is cyan blue #00a6ce with a hover of #007da4
+
+## Forms
+
+* Generally try to use Pure "aligned form"
+* Corners of form input fields should be .125em rounded
+* Checkboxes and radio buttons should always use a <label> tag around the label text, so that you 
+can click on the words and not just the button
+
+### Form Labels
+
+* Right align text against the input box/form field, padding-right of .5em
+* "Capitalize First Letters", "Unless somehow the label is a sentence"
+* Font color should be the same as the surrounding text on the page
+* Do not use colons unless there is a clear reason to
+* Generally avoid using placeholder text on an input field as the label. Once you start typing or 
+if there are form errors, it is not clear what the label is
+  * Exceptions are potentially ok with a very small number of fields or if the fields are obvious, 
+  like a login page with only email and password
+* If every field is required, do not use a required indicator
+  * If almost all fields are required, put “(optional)” after the labels for the few optional fields
+  * If there is a mix of required and optional fields, put an nbsp; and asterisk after the label 
+  for the required field in the same color as the label
+
+
+
+## Buttons
+
+* .125em rounded corners
+* "Capitalize First Letters", "Unless somehow the button is a sentence"
+* Font-weight: try to use "normal" where you can
+* Unless there is a specific reason to use icons within a button, let's not use them
+* Use standard Pure hover properties
+
+### Button Colors
+
+* Primary - orange (ff4c00)
+  * Main action buttons like "save"; most POST actions
+* Primary - cyan blue (00a6ce)
+  * Most GET actions; or POST actions with only light edits and/or if there is already an orange 
+  button and we need to differentiate
+* Secondary - gray (999)
+  * GET actions if there is already a cyan button
+* Other - red (f6323e)
+  * Not a standard Kotis color, but ok to use if we need a "delete" or "cancel" or just general 
+  warning button
+* Other - green (00b44f)
+  * Try not to use this unless we need to, not a standard Kotis color
+* Try to use the above color concepts very closely for internal uses. On an external page if the 
+buttons look bad or conflict with other graphics, please say something
+
+## Tables (data grids)
+
+* Header background is #777, with white bold text
+* Outside border and left/right cell borders should be #cbcbcb [Pure default]
+  * Header borders should be #999
+* Content should be left justified within a cell
+* Content should generally have padding of 0.5em
+* Alternate rows with background of #f2f2f2 and #fff [both Pure defaults]
+  * (Normally) Every other row, OR
+  * (Occasionally) Alternate based on groups of rows using the “sort by” field, ie if it’s sorted 
+  by date then everything with one date could be the same color and it switches at the next date. 
+  This is scenario specific, don’t use this option by default but we may want it in some cases. In 
+  this case we should add horizontal lines on each table row in #999.
+
+## Pagination
+
+* "Previous" and "Next" should always show up, but "previous" is disabled on first page and "next" 
+is disabled on last page
+* Non-disabled buttons: #333 font color, #999 border, #777 border on hover
+* Disabled buttons: #999 font color, #ddd border, no hover
+* Current page has #777 background and white text
+* Padding: 0.25em, 0.5em;
+* No italics
+* If the pagination is visually within some kind of horizontal bar (see the "design archive" for 
+example)
+  * Don’t show the borders around the links except on hover
+  * Don’t use background color (or white text) on current page
+
+## Dates
+
+* When displaying dates, show 2 digit years
+* Don’t display leading zeroes on days/months (ie **4/1/15** vs not 04/01/15 and not 4/1/2015)
+* Use jquery datepicker
+
+## Flash Messages
+
+* Success messages should have a full-width green background (00b44f)
+  * black text
+  * no border
+  * .5em padding
+  * .125em rounded corners
+* Failure/warning messages should be the same except red background (f6323e)
+
+## Headers
+
+Still working on this
+
+## Standards Will Change
+
+Make sure to share styles among all pages, so that changes can be done easily
+from a single place.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Kotis Style Guide
+
+## Viewing Code Locally
+
+1. Clone the repo locally and install the jekyll gem (`gem install jekyll`).
+2. Run `jekyll serve` and go to `localhost:4000/style-guide/`

--- a/_assets/_css/base/mixins.scss
+++ b/_assets/_css/base/mixins.scss
@@ -41,9 +41,9 @@
 }
 
 %default-links {
-  color: $kotis-orange;
+  color: $kotis-blue;
   &:hover {
-    color: $bright-orange;
+    color: $kotis-blue-secondary;
   }
 }
 

--- a/_assets/_css/base/variables.scss
+++ b/_assets/_css/base/variables.scss
@@ -1,11 +1,16 @@
 // COLORS
 
 $default-text-color: #333;
-$kotis-orange: #FB4F14;
+$kotis-orange: #ff4c00;
 $bright-orange: #ff6000;
-$kotis-blue: #36b;
+$kotis-blue: #00a6ce;
+$kotis-blue-secondary: #007da4;
 $bright-blue: #06f;
 $primary-color: #333;
+$kotis-gray: #999;
+$kotis-green: #00b44f;
+$kotis-red: #f6323e;
+
 
 $danger-text: rgb(202, 60, 60);
 

--- a/_assets/_css/styles/color-examples.scss
+++ b/_assets/_css/styles/color-examples.scss
@@ -1,0 +1,23 @@
+.primary-orange {
+  color: $kotis-orange;
+}
+
+.primary-blue {
+  color: $kotis-blue;
+}
+
+.secondary-gray {
+  color: $kotis-gray;
+}
+
+.other-red {
+  color: $kotis-red;
+}
+
+.other-green {
+  color: $kotis-green;  
+}
+
+.hover-blue {
+  color: $kotis-blue-secondary;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -13,5 +13,6 @@
 @import "styles/header";
 @import "styles/footer";
 @import "styles/markdown";
+@import "styles/color-examples";
 
 @import url(http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700);


### PR DESCRIPTION
Attempting to add front end style guide into Jay's existing guides. Is there a good way to test out how this looks? I'm using a Chrome add-in but it doesn't work exactly the same as Github flavored markdown. I also did not use any color because github markdown doesn't support that so I don't know what I'd need to change.
