### PR TITLE
add eof newline to sublime default options

### DIFF
--- a/01_ruby.md
+++ b/01_ruby.md
@@ -451,6 +451,7 @@ applications.
     ],
     "tab_size": 2,
     "translate_tabs_to_spaces": true,
-    "trim_trailing_white_space_on_save": true
+    "trim_trailing_white_space_on_save": true,
+    "ensure_newline_at_eof_on_save": true
   {% endhighlight %}
 


### PR DESCRIPTION
Adds sublime option `ensure_newline_at_eof_on_save` to default sublime text options.

![screenshot 5](https://cloud.githubusercontent.com/assets/5035874/8707608/9a678602-2aeb-11e5-9c8c-620988a47267.png)
